### PR TITLE
auth states now added

### DIFF
--- a/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/src/app/(app)/(auth)/sign-in/page.tsx
@@ -1,10 +1,15 @@
-import SignInView from '@/app/modules/auth/ui/views/sign-in-view'
-import React from 'react'
+import SignInView from "@/app/modules/auth/ui/views/sign-in-view";
+import { caller } from "@/trpc/server";
+import { redirect } from "next/navigation";
+import React from "react";
 
-const Page = () => {
-  return (
-    <SignInView />
-  )
-}
+const Page = async () => {
+  const session = await caller.auth.session();
 
-export default Page
+  if (session.user) {
+    redirect("/");
+  }
+  return <SignInView />;
+};
+
+export default Page;

--- a/src/app/(app)/(auth)/sign-up/page.tsx
+++ b/src/app/(app)/(auth)/sign-up/page.tsx
@@ -1,7 +1,15 @@
 import SignUpView from '@/app/modules/auth/ui/views/sign-up-view'
+import { caller } from '@/trpc/server'
+import { redirect } from 'next/navigation';
 import React from 'react'
 
-const Page = () => {
+const Page = async () => {
+  const session = await caller.auth.session();
+
+  if (session.user) {
+    redirect('/')
+  }
+  
   return (
     <div>
       <SignUpView />

--- a/src/app/(app)/(home)/navbar.tsx
+++ b/src/app/(app)/(home)/navbar.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Poppins } from "next/font/google";
@@ -7,6 +7,8 @@ import { usePathname } from "next/navigation";
 import React, { useState } from "react";
 import { NavbarSidebar } from "./navbar-sidebar";
 import { MenuIcon } from "lucide-react";
+import { useTRPC } from "@/trpc/client";
+import { useQuery } from "@tanstack/react-query";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -44,6 +46,9 @@ const NavbarItems = [
 export const Navbar = () => {
   const pathname = usePathname();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const trpc = useTRPC();
+  const session = useQuery(trpc.auth.session.queryOptions());
+
   return (
     <nav className="h-20 flex border-b justify-between font-medium bg-white ">
       <Link href={"/"} className="pl-6 flex items-center">
@@ -52,27 +57,65 @@ export const Navbar = () => {
         </span>
       </Link>
 
-      <NavbarSidebar open={isSidebarOpen} items={NavbarItems} onOpenChange={setIsSidebarOpen} />
+      <NavbarSidebar
+        open={isSidebarOpen}
+        items={NavbarItems}
+        onOpenChange={setIsSidebarOpen}
+      />
 
       <div className="items-center gap-4 hidden lg:flex">
         {NavbarItems.map((item) => (
-          <NavbarItem key={item.href} href={item.href} isActive={pathname === item.href}>
+          <NavbarItem
+            key={item.href}
+            href={item.href}
+            isActive={pathname === item.href}
+          >
             {item.children}
           </NavbarItem>
         ))}
       </div>
 
-      <div className="hidden lg:flex">
-        <Button asChild variant={"secondary"} className="border-l border-t-0 border-r-0 border-b-0 px-12 h-full rounded-none bg-white hover:bg-pink-400 transition-colors text-lg">
-          <Link prefetch href={'/sign-in'}>Log In</Link>
-        </Button>
-        <Button asChild variant={"default"} className="border-l border-t-0 border-r-0 border-b-0 px-12 h-full rounded-none bg-black text-white hover:text-black hover:bg-pink-400 transition-colors text-lg">
-          <Link prefetch href={'/sign-up'}>Start selling</Link>
-        </Button>
-      </div>
+      {session.data?.user ? (
+        <div className="hidden lg:flex">
+          <Button
+            asChild
+            variant={"default"}
+            className="border-l border-t-0 border-r-0 border-b-0 px-12 h-full rounded-none bg-black text-white hover:text-black hover:bg-pink-400 transition-colors text-lg"
+          >
+            <Link href={"/admin"}>
+              Dashboard
+            </Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="hidden lg:flex">
+          <Button
+            asChild
+            variant={"secondary"}
+            className="border-l border-t-0 border-r-0 border-b-0 px-12 h-full rounded-none bg-white hover:bg-pink-400 transition-colors text-lg"
+          >
+            <Link prefetch href={"/sign-in"}>
+              Log In
+            </Link>
+          </Button>
+          <Button
+            asChild
+            variant={"default"}
+            className="border-l border-t-0 border-r-0 border-b-0 px-12 h-full rounded-none bg-black text-white hover:text-black hover:bg-pink-400 transition-colors text-lg"
+          >
+            <Link prefetch href={"/sign-up"}>
+              Start selling
+            </Link>
+          </Button>
+        </div>
+      )}
 
       <div className="flex lg:hidden items-center justify-center">
-        <Button variant={'ghost'} className="size-12 border-transparent bg-white" onClick={() => setIsSidebarOpen(true)}>
+        <Button
+          variant={"ghost"}
+          className="size-12 border-transparent bg-white"
+          onClick={() => setIsSidebarOpen(true)}
+        >
           <MenuIcon />
         </Button>
       </div>

--- a/src/app/(app)/(home)/search-filters/search-input.tsx
+++ b/src/app/(app)/(home)/search-filters/search-input.tsx
@@ -1,9 +1,12 @@
 'use client'
 import { Input } from '@/components/ui/input';
-import { ListFilterIcon, SearchIcon } from 'lucide-react';
+import { BookmarkCheckIcon, ListFilterIcon, SearchIcon } from 'lucide-react';
 import React from 'react'
 import CategorySidebar from './category-sidebar';
 import { Button } from '@/components/ui/button';
+import { useTRPC } from '@/trpc/client';
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 
 interface Props {
   disabled?: boolean;
@@ -11,6 +14,8 @@ interface Props {
 
 const SearchInput = ({disabled}:Props) => {
   const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
+  const trpc = useTRPC();
+  const session = useQuery(trpc.auth.session.queryOptions());
   return (
     <div className='flex items-center gap-2 w-full'>
       <CategorySidebar open={isSidebarOpen} onOpenChange={setIsSidebarOpen} />
@@ -18,7 +23,6 @@ const SearchInput = ({disabled}:Props) => {
         <SearchIcon className='absolute left-3 top-1/2 -translate-y-1/2 size-4 text-neutral-500' />
         <Input className='pl-8' placeholder='Search products' disabled={disabled} />
       </div> 
-      {/* TODO: Add categories view all button */}
       <Button
         variant={'elevated'}
         className='size-12 shrink-0 flex lg:hidden'
@@ -26,7 +30,17 @@ const SearchInput = ({disabled}:Props) => {
         >
           <ListFilterIcon />
         </Button>
-      {/* TODO: Add library button */}
+      {session.data?.user && (
+        <Button
+        asChild //flex property
+        variant={'elevated'}
+        >
+          <Link href={'/library'}>
+            <BookmarkCheckIcon />
+            Library
+          </Link>
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/app/modules/auth/constants.ts
+++ b/src/app/modules/auth/constants.ts
@@ -1,2 +1,0 @@
-
-export const AUTH_COOKIE = 'payload-token';

--- a/src/app/modules/auth/ui/views/sign-in-view.tsx
+++ b/src/app/modules/auth/ui/views/sign-in-view.tsx
@@ -18,7 +18,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useTRPC } from "@/trpc/client";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
@@ -32,11 +32,13 @@ const SignInView = () => {
   const router = useRouter();
 
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const login = useMutation(trpc.auth.login.mutationOptions({
     onError: (error) => {
       toast.error(error.message);
     },
-    onSuccess: () => {
+    onSuccess: async() => {
+      await queryClient.invalidateQueries(trpc.auth.session.queryFilter())
       router.push('/');
     }
   }));

--- a/src/app/modules/auth/ui/views/sign-up-view.tsx
+++ b/src/app/modules/auth/ui/views/sign-up-view.tsx
@@ -19,7 +19,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useTRPC } from "@/trpc/client";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
@@ -33,11 +33,13 @@ const SignUpView = () => {
   const router = useRouter();
 
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const register = useMutation(trpc.auth.register.mutationOptions({
     onError: (error) => {
       toast.error(error.message);
     },
-    onSuccess: () => {
+    onSuccess: async() => {
+      await queryClient.invalidateQueries(trpc.auth.session.queryFilter());
       router.push('/');
     }
   }));

--- a/src/app/modules/auth/utils.ts
+++ b/src/app/modules/auth/utils.ts
@@ -1,0 +1,18 @@
+import { cookies as getCookies } from "next/headers";
+
+interface Props {
+  prefix:string;
+  value: string;
+}
+export const generateAuthCookie = async ({
+  prefix,
+  value
+}: Props) => {
+  const cookies = await getCookies();
+  cookies.set({
+    name: `${prefix}-token`,
+    value: value,
+    httpOnly: true,
+    path: "/",
+  });
+};

--- a/src/trpc/server.ts
+++ b/src/trpc/server.ts
@@ -11,3 +11,5 @@ export const trpc = createTRPCOptionsProxy({
   router: appRouter,
   queryClient: getQueryClient,
 });
+
+export const caller = appRouter.createCaller(createTRPCContext);


### PR DESCRIPTION
- Alternative ways to persist logged in state
  - Manually using  `next/headers `
    - use ` payload.config.cookiePrefix `
  - Using payload ` REST API `
    - automatically set cookie on login

- Use authenticated states
  - Display ` dashboard ` button when logged in
  - Display ` Library `  button when logged in